### PR TITLE
Ensuring unique data names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ test-bin/
 *.xml_gen
 
 # End of https://www.gitignore.io/api/xtext,eclipse,intellij
+
+.DS_Store

--- a/org.iot.codegenerator/src/org/iot/codegenerator/CodeGenerator.xtext
+++ b/org.iot.codegenerator/src/org/iot/codegenerator/CodeGenerator.xtext
@@ -32,11 +32,11 @@ Sensor:
 ;
 
 ExtSensor:
-	name=ID '('pins+=INT (',' pins+=INT)* ')'
+	type=ID '('pins+=INT (',' pins+=INT)* ')'
 ;
 
 OnbSensor:
-	name=ID
+	type=ID
 ;
 
 Variables:

--- a/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
+++ b/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
@@ -38,6 +38,9 @@ import org.iot.codegenerator.codeGenerator.Transformation
 import org.iot.codegenerator.codeGenerator.Unequal
 import org.iot.codegenerator.typing.TypeChecker
 import java.util.List
+import org.iot.codegenerator.codeGenerator.Variable
+import org.iot.codegenerator.codeGenerator.Variables
+import org.iot.codegenerator.codeGenerator.Provider
 
 /**
  * This class contains custom validation rules. 
@@ -189,6 +192,37 @@ class CodeGeneratorValidator extends AbstractCodeGeneratorValidator {
 				checkNoDuplicateDataName(datas)
 				return
 			}
+		}
+	}
+	
+	
+	def checkNoDuplicateVariableNamesInStatement(List<Variable> variables) {
+		val variableNameValues = new HashMap<String, Set<Variable>>
+
+		for (variable : variables) {
+			val name = variable.name
+			if (variableNameValues.containsKey(name)) {
+				variableNameValues.get(name).add(variable)
+			} else {
+				variableNameValues.put(name, Sets.newHashSet(variable))
+			}
+		}
+
+		for (Set<Variable> variableSet : variableNameValues.values) {
+			if (variableSet.size > 1) {
+				for (variable : variableSet) {
+					error('''duplicate '«variable.name»' ''', variable, CodeGeneratorPackage.eINSTANCE.variable_Name)
+				}
+			}
+		}
+	}
+	
+	@Check
+	def validateVariable(Variables variables){	
+		val eContainer = variables.eContainer
+		if (eContainer instanceof Provider){
+			val provider = eContainer as Provider
+			checkNoDuplicateVariableNamesInStatement(provider.variables.ids)
 		}
 	}
 

--- a/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
+++ b/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
@@ -234,13 +234,13 @@ class CodeGeneratorValidator extends AbstractCodeGeneratorValidator {
 
 	def validateTypes(TypeChecker.Type actual, TypeChecker.Type expected, EStructuralFeature error) {
 		if (expected != actual) {
-			error('''expected �expected� got �actual�''', error)
+			error('''expected «expected» got «actual»''', error)
 		}
 	}
 
 	def validateNumbers(TypeChecker.Type type, EStructuralFeature error) {
 		if (!type.isNumberType) {
-			error('''expected number got �type�''', error)
+			error('''expected number got «type»''', error)
 		}
 	}
 

--- a/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
+++ b/org.iot.codegenerator/src/org/iot/codegenerator/validation/CodeGeneratorValidator.xtend
@@ -3,18 +3,24 @@
  */
 package org.iot.codegenerator.validation
 
+import com.google.common.collect.Sets
 import com.google.inject.Inject
+import java.util.ArrayList
 import java.util.Arrays
+import java.util.HashMap
+import java.util.Set
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.xtext.validation.Check
 import org.iot.codegenerator.codeGenerator.And
+import org.iot.codegenerator.codeGenerator.Board
 import org.iot.codegenerator.codeGenerator.CodeGeneratorPackage
 import org.iot.codegenerator.codeGenerator.Conditional
+import org.iot.codegenerator.codeGenerator.Data
 import org.iot.codegenerator.codeGenerator.DeviceConf
 import org.iot.codegenerator.codeGenerator.Div
 import org.iot.codegenerator.codeGenerator.Equal
 import org.iot.codegenerator.codeGenerator.Exponent
-import org.iot.codegenerator.codeGenerator.ExtSensor
 import org.iot.codegenerator.codeGenerator.Filter
 import org.iot.codegenerator.codeGenerator.GreaterThan
 import org.iot.codegenerator.codeGenerator.GreaterThanEqual
@@ -25,16 +31,13 @@ import org.iot.codegenerator.codeGenerator.Minus
 import org.iot.codegenerator.codeGenerator.Mul
 import org.iot.codegenerator.codeGenerator.Negation
 import org.iot.codegenerator.codeGenerator.Not
-import org.iot.codegenerator.codeGenerator.Board
 import org.iot.codegenerator.codeGenerator.Or
 import org.iot.codegenerator.codeGenerator.Plus
 import org.iot.codegenerator.codeGenerator.Sensor
+import org.iot.codegenerator.codeGenerator.Transformation
 import org.iot.codegenerator.codeGenerator.Unequal
-import org.iot.codegenerator.codeGenerator.Variables
 import org.iot.codegenerator.typing.TypeChecker
-
-import static extension org.eclipse.xtext.EcoreUtil2.*
-import org.iot.codegenerator.codeGenerator.OnbSensor
+import java.util.List
 
 /**
  * This class contains custom validation rules. 
@@ -78,50 +81,114 @@ class CodeGeneratorValidator extends AbstractCodeGeneratorValidator {
 			return
 		}
 	}
-	 
-	@Check 
-	def validateBoard(Board board){ 
-		val b = UtilityBoard.getBoard(board.name, board.version) 
-		if (b === null){
+
+	@Check
+	def validateBoard(Board board) {
+		val b = UtilityBoard.getBoard(board.name, board.version)
+		if (b === null) {
 			error('''unsupported board type''', CodeGeneratorPackage.eINSTANCE.board_Name)
 		} else {
-			info('''«b.getVersion()» supports the following sensors: «b.getSensors()»''', CodeGeneratorPackage.eINSTANCE.board_Version)
+			info('''«b.getVersion()» supports the following sensors: «b.getSensors()»''',
+				CodeGeneratorPackage.eINSTANCE.board_Name)
 		}
 	}
 
-
-	
+// TODO: Fixme	
+//	@Check
+//	def validatePinsMatchesVars(Pin pin){
+//		if (pin.ids.size() < pin.vars.ids.size()){
+//			error('''exprects �pin.vars.ids.size()� pin inputs, got �pin.ids.size()�''', CodeGeneratorPackage.eINSTANCE.pin_Ids)
+//		} else if (pin.ids.size() > pin.vars.ids.size()){
+//			info('''number of pin inputs shuld match number of variables after "as"''', CodeGeneratorPackage.eINSTANCE.pin_Ids)
+//		}	
+//	} 
+//	@Check
+//	def validatePinsMatchesVars(Variables variables){
+//		val sensor = variables.getContainerOfType(Sensor)
+//		switch(sensor) {
+//			ExtSensor:
+//				if (sensor.pins.size() < variables.ids.size()) {
+//					error('''expected �sensor.pins.size()� pin inputs, got �variables.ids.size()�''', CodeGeneratorPackage.eINSTANCE.variables_Ids)
+//				} else if (sensor.pins.size() > variables.ids.size()) {
+//					warning('''number of pin inputs shuld match number of variables after "as"''', CodeGeneratorPackage.eINSTANCE.variables_Ids)					
+//				}
+//			OnbSensor:
+//				//TODO: Check keyword expectations
+//		}
+//	}
 	@Check
-	def validateOnbSensorKeyword(OnbSensor sensor){
-		val b = UtilityBoard.getBoard(sensor.getContainerOfType(Board))
-		if (!b.getSensors().contains(sensor.name)){
-			error('''no support for «sensor.name»''', CodeGeneratorPackage.eINSTANCE.sensor_Name)
-		} 
-	} 
-
-	@Check
-	def validatePinsMatchesVars(Variables variables){
-		val sensor = variables.getContainerOfType(Sensor)
-		switch(sensor) {
-			ExtSensor: null
-				// TODO: fix pin reference
-				//if (sensor.pins.size() < variables.ids.size()) {
-				//	error('''expected �sensor.pins.size()� pin inputs, got �variables.ids.size()�''', CodeGeneratorPackage.eINSTANCE.variables_Ids)
-				//} else if (sensor.pins.size() > variables.ids.size()) {
-				//	warning('''number of pin inputs shuld match number of variables after "as"''', CodeGeneratorPackage.eINSTANCE.variables_Ids)					
-				//}
-			OnbSensor: null
-				
-		}
-	}
-	
-	@Check
-	def validateLanguage(Language lang){
+	def validateLanguage(Language lang) {
 		var approved = Arrays.asList("python", "cplusplus")
-		if (!approved.contains(lang.name)){
-			error('''no support for language «lang.name», only "python" and "cplusplus"''', CodeGeneratorPackage.eINSTANCE.language_Name);
+		if (!approved.contains(lang.name)) {
+			error('''no support for language «lang.name», only "python" and "cplusplus"''',
+				CodeGeneratorPackage.eINSTANCE.language_Name)
 		} else {
-			info('''generator supports "python" and "cplusplus"''', CodeGeneratorPackage.eINSTANCE.language_Name);
+			info('''generator supports "python" and "cplusplus"''', CodeGeneratorPackage.eINSTANCE.language_Name)
+		}
+	}
+
+// TODO: Fixme	
+//	@Check
+//	def validateSource(Data data) {
+//	switch (data.eContainer) {
+//		ExtSensor case data.input instanceof I2C:
+//			error('''expected pin got i2c''', CodeGeneratorPackage.Literals.OUTPUT_DEFINITION__INPUT, INCORRECT_INPUT_TYPE_I2C)
+//		OnbSensor case data.input instanceof Pin:
+//			error('''expected i2c got pin''', CodeGeneratorPackage.Literals.OUTPUT_DEFINITION__INPUT, INCORRECT_INPUT_TYPE_PIN)
+//	}
+
+	def checkNoDuplicateDataName(List<Data> datas) {
+		val dataNameValues = new HashMap<String, Set<Data>>
+
+		for (data : datas) {
+			val name = data.name
+			if (dataNameValues.containsKey(name)) {
+				dataNameValues.get(name).add(data)
+			} else {
+				dataNameValues.put(name, Sets.newHashSet(data))
+			}
+		}
+
+		for (Set<Data> dataSet : dataNameValues.values) {
+			if (dataSet.size > 1) {
+				for (data : dataSet) {
+					error('''duplicate '«data.name»' ''', data, CodeGeneratorPackage.eINSTANCE.data_Name)
+				}
+			}
+		}
+	}
+
+	@Check
+	def validateData(Data data) {
+		var datas = new ArrayList<Data>
+		for (EObject eObject : data.eResource.getContents()) {
+			if (eObject instanceof DeviceConf) {
+				val deviceConf = eObject as DeviceConf
+				val board = deviceConf.board
+				val cloud = deviceConf.cloud
+				val fog = deviceConf.fog
+
+				if (board.size > 0) {
+					for (Sensor sensor : board.get(0).sensors) {
+						datas.addAll(sensor.datas)
+					}
+				}
+
+				if (cloud.size > 0) {
+					for (Transformation transformation : cloud.get(0).transformations) {
+						datas.addAll(transformation.datas)
+					}
+				}
+
+				if (fog.size > 0) {
+					for (Transformation transformation : fog.get(0).transformations) {
+						datas.addAll(transformation.datas)
+					}
+				}
+
+				checkNoDuplicateDataName(datas)
+				return
+			}
 		}
 	}
 
@@ -242,4 +309,5 @@ class CodeGeneratorValidator extends AbstractCodeGeneratorValidator {
 	def checkPower(Not not) {
 		not.value.type.validateTypes(TypeChecker.Type.BOOLEAN, CodeGeneratorPackage.Literals.NOT__VALUE)
 	}
+
 }


### PR DESCRIPTION
There seems to be a bug when marking duplicate data names in the board. When duplicate datas are found the sensor is marked instead. This does not happen in the fog or cloud.